### PR TITLE
fix:メモアプリを途中まで修正しました。

### DIFF
--- a/src/public/user/signin_complete.php
+++ b/src/public/user/signin_complete.php
@@ -16,22 +16,27 @@ if (empty($errors)) {
         $dbPassword
     );
 
-    $stmt = " SELECT
-    *
-    FROM users where email = '$email' ";
-    $stmt = $pdo->prepare($stmt);
-    $stmt->bindValue('email', $email, PDO::PARAM_INT);
+    //dbにuserテーブルを追加
+    $stmt = $pdo->prepare("SELECT * FROM users WHERE email = :email");
+    $stmt->bindParam(':email', $email, PDO::PARAM_STR);
     $stmt->execute();
     $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-    foreach ($users as $user) {
-        $singin_password = $user['password'];
-    }
-    if (!password_verify($password, $singin_password)) {
+    // ユーザーが存在するか確認するコード
+    if (count($users) > 0) {
+        $singin_password = $users[0]['password'];
+        if (!password_verify($password, $singin_password)) {
+            $errors[] = 'メールアドレスまたはパスワードが違います';
+        }
+    } else {
+        // ユーザーが存在しない場合のエラーメッセージ
         $errors[] = 'メールアドレスまたはパスワードが違います';
     }
 }
 ?>
+
+
+
 
 <!DOCTYPE html>
 <html>

--- a/src/public/user/signup.php
+++ b/src/public/user/signup.php
@@ -12,7 +12,7 @@ session_start();
 
     <h1 style="text-align:center;margin-top: 2em;margin-bottom: 1em;" class="h1_log">会員登録</h1>
 <form action="/user/signup_complete.php" method="post" class="form_log">
-     <input type="username" name="username" class="textbox un" placeholder="User Name"><br>
+     <input type="text" name="name" class="textbox un" placeholder="User Name"><br>
      <input type="email" name="email" class="textbox un" placeholder="Email"><br>
      <input type="password" name="password" class="textbox pass" placeholder="Password"><br>
      <input type="password" name="password_check" class="textbox pass" placeholder="Password確認"><br>

--- a/src/public/user/signup_complete.php
+++ b/src/public/user/signup_complete.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 
-$username = $_POST['username'];
+$name = $_POST['name'];
 $email = $_POST['email'];
 $password = password_hash($_POST['password'], PASSWORD_DEFAULT);
 $password_check = $_POST['password_check'];
@@ -34,15 +34,19 @@ $statement->execute();
 $emails = $statement->fetchAll(PDO::FETCH_ASSOC);
 
 $errors3 = [];
-$value_count = array_count_values(array_column($emails,'email'));
-$max = max($value_count); 
-if ($max != 1) {
-  $errors3[] = 'すでに保存されているメールアドレスです';
-  $_SESSION['errors3'] = $errors3;
-} 
+$email_column = array_column($emails,'email'); 
+$value_count = array_count_values($email_column);
+$max = 0; 
+if (!empty($value_count)) {
+  $max = max($value_count);
+}
 
+if ($max > 1) {
+    $errors3[] = 'すでに保存されているメールアドレスです';
+    $_SESSION['errors3'] = $errors3;
+}
 
-if(isset($_POST['username'])) {
+if(isset($_POST['name'])) {
   $dbUserName = 'root';
   $dbPassword = 'password';
   $pdo = new PDO(
@@ -52,14 +56,15 @@ if(isset($_POST['username'])) {
   );
 
 $stmt = $pdo->prepare("INSERT INTO users(
-	username, email, password
+    name, email, password
 ) VALUES (
-	:username, :email, :password
+    :name, :email, :password
 )");
 
-$stmt->bindParam(':username', $username, PDO::PARAM_STR);
+$stmt->bindParam(':name', $name, PDO::PARAM_STR);
 $stmt->bindParam(':email', $email, PDO::PARAM_STR);
-$stmt->bindParam(':password', password_hash($password, PASSWORD_DEFAULT), PDO::PARAM_STR);
+$hashed_password = password_hash($password, PASSWORD_DEFAULT);
+$stmt->bindParam(':password', $hashed_password, PDO::PARAM_STR);
 $res = $stmt->execute();
 }
 ?>
@@ -73,7 +78,6 @@ $res = $stmt->execute();
  
 <body>
   <div>
-
    <?php if (!empty($_SESSION['errors'] ) || !empty($_SESSION['errors2'])|| !empty($_SESSION['errors3'] )): ?>
       <meta http-equiv="refresh" content="1;URL=http://localhost:8080/user/signup.php">
    <?php endif; ?>


### PR DESCRIPTION
## 作業対象

[作業をした教材のURL]
[https://www.notion.so/3-87a32a694bf741efb83c64de2f8341b6?pvs=4](url)
[作成したページのURL(signup.php)
(http://localhost:8080/user/signup.php)

## 作業詳細

ログイン機能のエラーを途中まで修正しました。

解決できていない問題点↓

アカウント作成画面：ユーザー情報はDBに問題なく登録されますが、"パスワードが一致しません"　"すでに保存されているメールアドレスです"というエラー文が必ず出てしまいます。

ログイン画面：DBに保存されているものと合っているはずなのに"メールアドレスまたはパスワードが違います"というエラー文が出てしまいます。

メモ一覧ページ：写真↓のエラーが出てしまいます。

![2023-06-05 21 57のイメージ](https://github.com/mikan19/memo-error/assets/128659635/94a3931e-2f35-4cff-bf96-353fccf15f87)





